### PR TITLE
Add test to use express server with the healthcheck middleware.

### DIFF
--- a/lib/healthcheck.js
+++ b/lib/healthcheck.js
@@ -13,7 +13,7 @@ module.exports = function (options) {
     if (options.test.length === 0) {
         var test = options.test;
         options.test = function (callback) {
-            setImmediate(callback(test()));
+            callback(test());
         };
     }
     return function (req, res, next) {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
   "homepage": "https://github.com/lennym/express-healthcheck",
   "devDependencies": {
     "chai": "^1.10.0",
+    "express": "^4.13.4",
     "mocha": "^2.1.0",
     "sinon": "^1.12.2",
-    "sinon-chai": "^2.6.0"
+    "sinon-chai": "^2.6.0",
+    "supertest": "^1.2.0"
   }
 }

--- a/test/spec.healthcheck.js
+++ b/test/spec.healthcheck.js
@@ -164,4 +164,17 @@ describe('express-healthcheck', function () {
 
     });
 
+    it('integrates with an express server', function (done) {
+      var app = require('express')();
+      var request = require('supertest');
+      app.use('/healthcheck', healthcheck());
+      request(app)
+        .get('/healthcheck')
+        .expect(200)
+        .expect(function (res) {
+          res.body.should.have.property('uptime');
+        })
+        .end(done);
+    });
+
 });


### PR DESCRIPTION
Remove the call to `setImmediate` to remove the error described in
issue #1.

Add express and supertest to the `devDependencies` to aid in the test.

Should fix #1 
