### PR TITLE
Change package.json license to MIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/lennym/express-healthcheck.git"
   },
   "author": "Leonard Martin",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/lennym/express-healthcheck/issues"
   },


### PR DESCRIPTION
The license of this repo seems to be MIT, but in the package.json ISC was defined.

This PR fixes this inconsistency.